### PR TITLE
Issue #6: Allow Solr 4.x, 5.x, and 6.x versions to be managed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,17 @@ python:
   # - "3.5"
 
 install:
+  # Install requirements.
   - pip install -r ansible-requirements.txt
-  - pip install ansible-container[docker]
+
+  # Install ansible-container.
+  - git clone https://github.com/ansible/ansible-container.git
+  - cd ansible-container
+  - pip install -e .[docker]
+  # (Source build required until 0.9.2 is released.)
+  # - pip install ansible-container[docker]
 
 script:
-  - ansible-container --debug --var-file vars.yml build
+  - ansible-container --debug --var-file vars-6.x.yml build
+  # - ansible-container --debug --var-file vars-5.x.yml build
+  # - ansible-container --debug --var-file vars-4.x.yml build

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
   - git clone https://github.com/ansible/ansible-container.git
   - cd ansible-container
   - pip install -e .[docker]
+  - cd ..
   # (Source build required until 0.9.2 is released.)
   # - pip install ansible-container[docker]
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,17 @@ Before using this project to build and maintain a Solr images for Docker, you ne
 
   1. Build the Solr Docker image; run this command in the root directory:
 
-         ansible-container --var-file vars.yml build
+         ansible-container --var-file vars-6.x.yml build
 
   1. Once the image is built, you can run `docker images` to see the `acsolr-solr` image that was generated.
 
+Older Solr versions are also supported—specify the vars file for the version you would like to install to switch to that version of Solr. (**Note**: Until 0.9.2+ is released, you must [install and use Ansible Container from source](https://docs.ansible.com/ansible-container/installation.html#running-from-source) due to [this PR only being in devel so far](https://github.com/ansible/ansible-container/pull/609).)
+
 ### Run the image as a container
 
-    ansible-container run
+    ansible-container --var_file vars-6.x.yml run
+
+**Note**: The `--var_file` option currently seems to not work with `run`, so you may need to just use `run` alone and paste any relevant variables into the `container.yml` file, at least until [this issue](https://github.com/ansible/ansible-container/issues/643) is resolved.
 
 You should be able to reach the Solr dashboard by accessing [http://localhost:8983/](http://localhost:8983/) in your browser.
 
@@ -49,24 +53,26 @@ You should be able to reach the Solr dashboard by accessing [http://localhost:89
 
 ### Push the image to Docker Hub
 
-Currently, the process for updating this image on Docker Hub is manual. Eventually this will be automated via Travis CI using `ansible-container push`.
+Currently, the process for updating this image on Docker Hub is manual. Eventually this will be automated via Travis CI using `ansible-container push` (currently, this is waiting on [this issue](https://github.com/ansible/ansible-container/issues/630) to be resolved).
 
   1. Log into Docker Hub on the command line:
 
          docker login --username=geerlingguy
 
-  1. Tag the latest version:
+  1. Tag the latest version (only if this is the latest/default version):
 
          docker tag [image id] geerlingguy/solr:latest
 
   1. Tag the Solr major version:
 
          docker tag [image id] geerlingguy/solr:6.x # or 5.x, 4.x...
+         docker tag [image id] geerlingguy/solr:6.6.0 # the specific version
 
   1. Push tags to Docker Hub:
 
-         docker push geerlingguy/solr:latest
+         docker push geerlingguy/solr:latest # (if this was just tagged)
          docker push geerlingguy/solr:6.x # or 5.x, 4.x...
+         docker push geerlingguy/solr:6.6.0 # the specific version
 
 
 ## License

--- a/requirements.yml
+++ b/requirements.yml
@@ -7,4 +7,4 @@
 - src: geerlingguy.java
   version: 1.7.2
 - src: geerlingguy.solr
-  version: 3.6.0
+  version: 3.6.1

--- a/vars-4.x.yml
+++ b/vars-4.x.yml
@@ -1,0 +1,9 @@
+---
+java_packages:
+  - openjdk-8-jdk
+
+solr_remove_cruft: true
+
+solr_version: "4.10.4"
+
+container_start_command: ["/opt/solr/bin/solr", "start", "-f"]

--- a/vars-5.x.yml
+++ b/vars-5.x.yml
@@ -1,0 +1,9 @@
+---
+java_packages:
+  - openjdk-8-jdk
+
+solr_remove_cruft: true
+
+solr_version: "5.5.4"
+
+container_start_command: ["/opt/solr/bin/solr", "start", "-f", "-force"]

--- a/vars-6.x.yml
+++ b/vars-6.x.yml
@@ -1,0 +1,9 @@
+---
+java_packages:
+  - openjdk-8-jdk
+
+solr_remove_cruft: true
+
+solr_version: "6.6.0"
+
+container_start_command: ["/opt/solr/bin/solr", "start", "-f", "-force"]

--- a/vars.yml
+++ b/vars.yml
@@ -1,3 +1,0 @@
----
-java_packages:
-  - openjdk-8-jdk


### PR DESCRIPTION
See #6.