### PR TITLE
Bumps Solr version to 9.4.0 

### DIFF
--- a/vars/9.x.yml
+++ b/vars/9.x.yml
@@ -4,7 +4,7 @@ java_packages:
 
 solr_remove_cruft: true
 
-solr_version: "9.2.1"
+solr_version: "9.4.0"
 # TODO: See https://github.com/geerlingguy/ansible-role-solr/issues/132
 solr_cores: ~
 


### PR DESCRIPTION
# What
Solr 9.4.0 has been [released](https://cwiki.apache.org/confluence/display/SOLR/ReleaseNote9_4_0) and the docker image starts correctly after https://github.com/geerlingguy/solr-container/pull/29 so I think it's a good idea to use it as the latest tag.